### PR TITLE
Add check for expired event prior to adding event to alerts.

### DIFF
--- a/app/src/main/java/com/github/quarck/calnotify/calendar/CalendarIntents.kt
+++ b/app/src/main/java/com/github/quarck/calnotify/calendar/CalendarIntents.kt
@@ -50,7 +50,8 @@ object CalendarIntents {
         val canAddEventTime =
                 event.instanceStartTime != 0L &&
                         event.instanceEndTime != 0L &&
-                        event.instanceStartTime < event.instanceEndTime
+                        event.instanceStartTime < event.instanceEndTime &&
+                        event.instanceEndTime > System.currentTimeMillis()
 
         if (shouldAddEventTime && canAddEventTime) {
             // only add if it is a valid instance start / end time, and we need both


### PR DESCRIPTION
This is useful for Google calendars that sync with an external calendar, for example Office365. 

The sync process will often clear the dismissed flag on calendar events. This will result in alerts being generated for past events. This change adds a check for the event end time and the current system time. If the event end time is in the past, then skip adding the event to the alert queue. 